### PR TITLE
Bugfixed: pace activities uses spm for cadence instead of rpm.

### DIFF
--- a/pyopentracks/io/parser/fit/messages.py
+++ b/pyopentracks/io/parser/fit/messages.py
@@ -330,6 +330,8 @@ class FitRecordMessage:
         values = record.get_values()
         self._point = Point()
 
+        print(values)
+
         self._point.latitude, self._point.longitude = self._lat_and_lon(values)
         self._point.distance = values["distance"] if "distance" in values else None
         self._point.time = dt_to_aware_locale_ms(values["timestamp"]) if "timestamp" in values else None
@@ -338,6 +340,8 @@ class FitRecordMessage:
         self._point.gain, self._point.loss = manager.get_and_reset()
         self._point.heart_rate = values["heart_rate"] if "heart_rate" in values else None
         self._point.cadence = values["cadence"] if "cadence" in values else None
+        if self._point.cadence is not None:
+            self._point.cadence += values["fractional_cadence"] if "fractional_cadence" in values else 0
         self._point.power = values["power"] if "power" in values else None
         self._point.temperature = values["temperature"] if "temperature" else None
 

--- a/pyopentracks/models/aggregated_stats.py
+++ b/pyopentracks/models/aggregated_stats.py
@@ -39,12 +39,14 @@ class AggregatedStats:
         self._avg_elevation_gain_m = args[9]
         self._avg_speed_mps = args[10]
         self._avg_heart_rate_bpm = args[11]
-        self._max_time_ms = args[12]
-        self._max_moving_time_ms = args[13]
-        self._max_distance_m = args[14]
-        self._max_elevation_gain_m = args[15]
-        self._max_speed_mps = args[16]
-        self._max_heart_rate_bpm = args[17]
+        self._avg_cadence_rpm = args[12]
+        self._max_time_ms = args[13]
+        self._max_moving_time_ms = args[14]
+        self._max_distance_m = args[15]
+        self._max_elevation_gain_m = args[16]
+        self._max_speed_mps = args[17]
+        self._max_heart_rate_bpm = args[18]
+        self._max_cadence_rpm = args[19]
 
     @property
     def category(self):
@@ -107,6 +109,10 @@ class AggregatedStats:
         return se.hr_to_str(self._avg_heart_rate_bpm)
 
     @property
+    def avg_cadence(self):
+        return se.cadence_to_str(self._avg_cadence_rpm, self._category)
+
+    @property
     def max_time(self):
         return tu.ms_to_str(self._max_time_ms)
 
@@ -129,6 +135,10 @@ class AggregatedStats:
     @property
     def max_heart_rate(self):
         return se.hr_to_str(self._max_heart_rate_bpm)
+
+    @property
+    def max_cadence(self):
+        return se.cadence_to_str(self._max_cadence_rpm, self._category)
 
     @property
     def activities_label(self):
@@ -157,3 +167,8 @@ class AggregatedStats:
     @property
     def heart_rate_label(self):
         return _("Heart Rate")
+
+    @property
+    def cadence_label(self):
+        return _("Cadence")
+

--- a/pyopentracks/models/database.py
+++ b/pyopentracks/models/database.py
@@ -375,12 +375,14 @@ class Database:
                     AVG(stats.elevationgain) avg_gain,
                     SUM(stats.totaldistance) / (SUM(stats.movingtime) / 1000) avg_speed,
                     AVG(stats.avghr) avg_heart_rate,
+                    AVG(stats.avgcadence) avg_cadence,
                     MAX(stats.totaltime) max_time,
                     MAX(stats.movingtime) max_moving_time,
                     MAX(stats.totaldistance) max_distance,
                     MAX(stats.elevationgain) max_gain,
                     MAX(stats.maxspeed) max_speed,
-                    MAX(stats.maxhr) max_heart_rate
+                    MAX(stats.maxhr) max_heart_rate,
+                    MAX(stats.maxcadence) max_cadence
                 FROM stats, activities
                 WHERE stats._id=activities.statsid
                 {where}

--- a/pyopentracks/models/segment_track.py
+++ b/pyopentracks/models/segment_track.py
@@ -187,11 +187,11 @@ class SegmentTrack(Model):
 
     @property
     def avgcadence(self):
-        return SensorUtils.cadence_to_str(self._avgcadence)
+        return SensorUtils.cadence_to_str(self._avgcadence, self.activity.category)
 
     @property
     def maxcadence(self):
-        return SensorUtils.cadence_to_str(self._maxcadence)
+        return SensorUtils.cadence_to_str(self._maxcadence, self.activity.category)
 
     @activity.setter
     def activity(self, activity):

--- a/pyopentracks/models/stats.py
+++ b/pyopentracks/models/stats.py
@@ -266,9 +266,8 @@ class Stats(Model):
     def max_cadence_rpm(self):
         return self._maxcadence_rpm
 
-    @property
-    def max_cadence(self):
-        return se.cadence_to_str(self._maxcadence_rpm)
+    def max_cadence(self, category: str):
+        return se.cadence_to_str(self._maxcadence_rpm, category)
 
     @property
     def max_cadence_label(self):
@@ -278,9 +277,8 @@ class Stats(Model):
     def avg_cadence_rpm(self):
         return self._avgcadence_rpm
 
-    @property
-    def avg_cadence(self):
-        return se.cadence_to_str(self._avgcadence_rpm)
+    def avg_cadence(self, category: str):
+        return se.cadence_to_str(self._avgcadence_rpm, category)
 
     @property
     def avg_cadence_label(self):

--- a/pyopentracks/utils/utils.py
+++ b/pyopentracks/utils/utils.py
@@ -477,16 +477,22 @@ class SensorUtils:
         return str(int(hr_bpm)) + " bpm" if hr_bpm is not None else "-"
 
     @staticmethod
-    def cadence_to_str(cadence_rpm: float) -> str:
+    def cadence_to_str(cadence_rpm: float, category: str) -> str:
         """From float representation cadence to cadence string.
 
         Arguments:
         cadence_rpm -- cadence in rpm.
+        category -- category of the activity.
 
         Returns:
         An string representing the cadence.
         """
-        return str(int(cadence_rpm)) + " rpm" if cadence_rpm is not None else "-"
+        if not cadence_rpm:
+            return "-"
+        if TypeActivityUtils.is_speed(category):
+            return str(int(cadence_rpm)) + " rpm"
+        else:
+            return str(int(float(cadence_rpm) * 2)) + " spm"
 
     @staticmethod
     def temperature_to_str(temperature: float) -> str:

--- a/pyopentracks/views/layouts/activity_summary_layout.py
+++ b/pyopentracks/views/layouts/activity_summary_layout.py
@@ -324,9 +324,9 @@ class TrackActivitySummaryStatsLayout(ActivitySummaryStatsLayout):
 
         if stats.max_cadence_rpm is not None or stats.avg_cadence_rpm is not None:
             # Max. cadence
-            self._add_item(stats.max_cadence_label, stats.max_cadence)
+            self._add_item(stats.max_cadence_label, stats.max_cadence(category))
             # Avg. cadence
-            self._add_item(stats.avg_cadence_label, stats.avg_cadence)
+            self._add_item(stats.avg_cadence_label, stats.avg_cadence(category))
 
 
 class SetActivitySummaryStatsLayout(ActivitySummaryStatsLayout):

--- a/pyopentracks/views/layouts/analytic_layout.py
+++ b/pyopentracks/views/layouts/analytic_layout.py
@@ -372,6 +372,8 @@ class AnalyticTotalsYear(Gtk.Box):
             _("Elevation\nGain"),
             _("Heart Rate\nMaximum"),
             _("Heart Rate\nAverage"),
+            _("Cadence\nMaximum"),
+            _("Cadence\nAverage"),
             _("Speed/Pace\nAverage")
         )
         for i, aggregated in enumerate(aggregated_list):
@@ -385,6 +387,8 @@ class AnalyticTotalsYear(Gtk.Box):
             box_gain = self._build_info_box(aggregated.total_elevation_gain)
             box_hr_max = self._build_info_box(aggregated.max_heart_rate)
             box_hr_avg = self._build_info_box(aggregated.avg_heart_rate)
+            box_cadence_max = self._build_info_box(aggregated.max_cadence)
+            box_cadence_avg = self._build_info_box(aggregated.avg_cadence)
             box_speed_pace_avg = self._build_info_box(aggregated.avg_speed)
 
             grid.attach(box_icon, 0, i + 1, 1, 1)
@@ -395,7 +399,9 @@ class AnalyticTotalsYear(Gtk.Box):
             grid.attach(box_gain, 5, i + 1, 1, 1)
             grid.attach(box_hr_max, 6, i + 1, 1, 1)
             grid.attach(box_hr_avg, 7, i + 1, 1, 1)
-            grid.attach(box_speed_pace_avg, 8, i + 1, 1, 1)
+            grid.attach(box_cadence_max, 8, i + 1, 1, 1)
+            grid.attach(box_cadence_avg, 9, i + 1, 1, 1)
+            grid.attach(box_speed_pace_avg, 10, i + 1, 1, 1)
         self.append(grid)
 
     def _build_headers(self, grid, *header_labels):

--- a/pyopentracks/views/layouts/layout_builder.py
+++ b/pyopentracks/views/layouts/layout_builder.py
@@ -173,8 +173,6 @@ class SportSummaryLayoutBuilder:
         self._args = args
 
     def make(self):
-        
-
         if self._category is None:
             return SummaryMovingSport(*self._args if type(self._args) == tuple else self._args)
         elif self._category in ("rock_climbing", "training"):

--- a/pyopentracks/views/layouts/summary_sport_layout.py
+++ b/pyopentracks/views/layouts/summary_sport_layout.py
@@ -126,6 +126,8 @@ class SummaryMovingSport(SummarySport):
         grid.attach(self._value(str(self._aggregated.avg_speed)), 1, 4, 1, 1)
         grid.attach(self._label(_("Heart Rate")), 0, 5, 1, 1)
         grid.attach(self._value(str(self._aggregated.avg_heart_rate)), 1, 5, 1, 1)
+        grid.attach(self._label(_("Cadence")), 0, 6, 1, 1)
+        grid.attach(self._value(str(self._aggregated.avg_cadence)), 1, 6, 1, 1)
         box.append(grid)
 
         self._h_stats_box.append(box)
@@ -150,6 +152,8 @@ class SummaryMovingSport(SummarySport):
         grid.attach(self._value(str(self._aggregated.max_speed)), 1, 4, 1, 1)
         grid.attach(self._label(_("Heart Rate")), 0, 5, 1, 1)
         grid.attach(self._value(str(self._aggregated.max_heart_rate)), 1, 5, 1, 1)
+        grid.attach(self._label(_("Cadence")), 0, 6, 1, 1)
+        grid.attach(self._value(str(self._aggregated.max_cadence)), 1, 6, 1, 1)
         box.append(grid)
 
         self._h_stats_box.append(box)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -339,9 +339,9 @@ class TestSensorUtils(unittest.TestCase):
         self.assertEqual(SensorUtils.hr_to_str(95.87), "95 bpm")
 
     def test_cadence_to_str(self):
-        self.assertEqual(SensorUtils.cadence_to_str(None), "-")
-        self.assertEqual(SensorUtils.cadence_to_str(0), "0 rpm")
-        self.assertEqual(SensorUtils.cadence_to_str(95.87), "95 rpm")
+        self.assertEqual(SensorUtils.cadence_to_str(None, "cycling"), "-")
+        self.assertEqual(SensorUtils.cadence_to_str(0, "cycling"), "0 rpm")
+        self.assertEqual(SensorUtils.cadence_to_str(95.87, "cycling"), "95 rpm")
 
 
 class TestStatsUtils(unittest.TestCase):


### PR DESCRIPTION
In FIT files fractional_cadence (field_id=53) has to be in consideration.
Bugfixed: cadence wasn't shown in aggregated stats.